### PR TITLE
Replace api to get all boundaries ids with api to get all boundaries infos (id, filename, scenario time)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,10 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-model</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <apache.commons.vfs2.version>2.6.0</apache.commons.vfs2.version>
         <commons.net.version>3.7</commons.net.version>
         <commons-lang3.version>3.9</commons-lang3.version>
+        <jackson-datatype.version>2.11.0</jackson-datatype.version>
     </properties>
 
     <build>
@@ -143,6 +144,12 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson-datatype.version}</version>
+        </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -163,6 +170,10 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <!-- Runtime dependencies -->

--- a/src/main/java/org/gridsuite/boundary/importer/job/BoundaryAcquisitionJob.java
+++ b/src/main/java/org/gridsuite/boundary/importer/job/BoundaryAcquisitionJob.java
@@ -36,7 +36,7 @@ public final class BoundaryAcquisitionJob {
     }
 
     private static void importBoundary(byte[] boundaryContent,
-                                       List<String> allBoundaryIds,
+                                       List<BoundaryInfo> allBoundaryInfos,
                                        String fileName,
                                        CgmesBoundaryServiceRequester cgmesBoundaryServiceRequester,
                                        List<String> filesImported,
@@ -47,7 +47,7 @@ public final class BoundaryAcquisitionJob {
             FullModel fullModel = FullModel.parse(reader);
             String id = fullModel.getId();
 
-            if (!allBoundaryIds.contains(id)) {
+            if (allBoundaryInfos.stream().noneMatch(b -> b.getId().equals(id))) {
                 // import the boundary to the cgmes boundary server
                 LOGGER.info("Importing boundary file '{}'...", fileName);
 
@@ -64,7 +64,7 @@ public final class BoundaryAcquisitionJob {
     }
 
     private static void handleZipBoundaryContainer(TransferableFile acquiredFile,
-                                                   List<String> allBoundaryIds,
+                                                   List<BoundaryInfo> allBoundaryInfos,
                                                    CgmesBoundaryServiceRequester cgmesBoundaryServiceRequester,
                                                    List<String> filesImported,
                                                    List<String> filesAlreadyImported,
@@ -87,7 +87,7 @@ public final class BoundaryAcquisitionJob {
 
                     byte[] boundaryContent = zis.readAllBytes();
 
-                    importBoundary(boundaryContent, allBoundaryIds, fileName, cgmesBoundaryServiceRequester, filesImported, filesAlreadyImported, filesImportFailed);
+                    importBoundary(boundaryContent, allBoundaryInfos, fileName, cgmesBoundaryServiceRequester, filesImported, filesAlreadyImported, filesImportFailed);
                 }
 
                 entry = zis.getNextEntry();
@@ -118,14 +118,14 @@ public final class BoundaryAcquisitionJob {
             List<String> filesImportFailed = new ArrayList<>();
 
             if (!filesToAcquire.isEmpty()) {
-                // Get all available boundary ids from cgmes boundary server
-                List<String> allBoundaryIds = cgmesBoundaryServiceRequester.getBoundariesIds();
+                // Get all available boundary infos from cgmes boundary server
+                List<BoundaryInfo> allBoundaryInfos = cgmesBoundaryServiceRequester.getBoundariesInfos();
 
                 for (Map.Entry<String, String> fileInfo : filesToAcquire.entrySet()) {
                     // get boundary container zip file
                     TransferableFile acquiredFile = boundaryAcquisitionServer.getFile(fileInfo.getKey(), fileInfo.getValue());
 
-                    handleZipBoundaryContainer(acquiredFile, allBoundaryIds, cgmesBoundaryServiceRequester, filesImported, filesAlreadyImported, filesImportFailed);
+                    handleZipBoundaryContainer(acquiredFile, allBoundaryInfos, cgmesBoundaryServiceRequester, filesImported, filesAlreadyImported, filesImportFailed);
                 }
             }
 

--- a/src/main/java/org/gridsuite/boundary/importer/job/BoundaryInfo.java
+++ b/src/main/java/org/gridsuite/boundary/importer/job/BoundaryInfo.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.boundary.importer.job;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ */
+@AllArgsConstructor
+@Getter
+public class BoundaryInfo {
+
+    private String id;
+
+    private String filename;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private LocalDateTime scenarioTime;
+}

--- a/src/main/java/org/gridsuite/boundary/importer/job/BoundaryInfo.java
+++ b/src/main/java/org/gridsuite/boundary/importer/job/BoundaryInfo.java
@@ -9,6 +9,7 @@ package org.gridsuite.boundary.importer.job;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class BoundaryInfo {
 

--- a/src/main/java/org/gridsuite/boundary/importer/job/CgmesBoundaryServiceRequester.java
+++ b/src/main/java/org/gridsuite/boundary/importer/job/CgmesBoundaryServiceRequester.java
@@ -7,6 +7,7 @@
 package org.gridsuite.boundary.importer.job;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +20,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.*;
 
 /**
@@ -92,10 +94,10 @@ public class CgmesBoundaryServiceRequester {
         return HttpRequest.BodyPublishers.ofByteArrays(byteArrays);
     }
 
-    public List<String> getBoundariesIds() throws InterruptedException {
+    public List<BoundaryInfo> getBoundariesInfos() throws InterruptedException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(serviceUrl + API_VERSION + "/boundaries/ids"))
+                .uri(URI.create(serviceUrl + API_VERSION + "/boundaries/infos"))
                 .GET()
                 .build();
 
@@ -103,17 +105,18 @@ public class CgmesBoundaryServiceRequester {
             if (response.statusCode() == 200) {
                 String json = response.body();
 
-                List<String> result = new ArrayList<>();
+                List<BoundaryInfo> result = new ArrayList<>();
                 JSONArray array = new JSONArray(json);
                 for (int i = 0; i < array.length(); i++) {
-                    result.add(array.getString(i));
+                    JSONObject obj = array.getJSONObject(i);
+                    result.add(new BoundaryInfo(obj.getString("id"), obj.getString("filename"), LocalDateTime.parse(obj.getString("scenarioTime"))));
                 }
                 return result;
             }
         } catch (IOException e) {
-            LOGGER.error("I/O Error while getting all boundary ids");
+            LOGGER.error("I/O Error while getting all boundary infos");
         } catch (InterruptedException e) {
-            LOGGER.error("Interruption while getting all boundary ids");
+            LOGGER.error("Interruption while getting all boundary infos");
             Thread.currentThread().interrupt();
         }
         return Collections.emptyList();

--- a/src/main/java/org/gridsuite/boundary/importer/job/CgmesBoundaryServiceRequester.java
+++ b/src/main/java/org/gridsuite/boundary/importer/job/CgmesBoundaryServiceRequester.java
@@ -7,7 +7,6 @@
 package org.gridsuite.boundary.importer.job;
 
 import org.json.JSONArray;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +107,7 @@ public class CgmesBoundaryServiceRequester {
                 List<BoundaryInfo> result = new ArrayList<>();
                 JSONArray array = new JSONArray(json);
                 for (int i = 0; i < array.length(); i++) {
-                    JSONObject obj = array.getJSONObject(i);
+                    var obj = array.getJSONObject(i);
                     result.add(new BoundaryInfo(obj.getString("id"), obj.getString("filename"), LocalDateTime.parse(obj.getString("scenarioTime"))));
                 }
                 return result;

--- a/src/test/java/org/gridsuite/boundary/importer/job/BoundaryImportJobTest.java
+++ b/src/test/java/org/gridsuite/boundary/importer/job/BoundaryImportJobTest.java
@@ -25,6 +25,7 @@ import org.mockserver.verify.VerificationTimes;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -179,5 +180,14 @@ public class BoundaryImportJobTest {
         BoundaryAcquisitionJob.main(args);
 
         mockServer.getClient().verify(request().withMethod("POST").withPath("/v1/boundaries"), VerificationTimes.exactly(0));
+    }
+
+    @Test
+    public void boundaryInfoTest() {
+        LocalDateTime date = LocalDateTime.of(2021, 5, 10, 10, 0, 0);
+        BoundaryInfo info = new BoundaryInfo("urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "20210315T0000Z__ENTSOE_TPBD_002.xml", date);
+        assertEquals("urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb", info.getId());
+        assertEquals("20210315T0000Z__ENTSOE_TPBD_002.xml", info.getFilename());
+        assertEquals(date, info.getScenarioTime());
     }
 }

--- a/src/test/java/org/gridsuite/boundary/importer/job/BoundaryImportJobTest.java
+++ b/src/test/java/org/gridsuite/boundary/importer/job/BoundaryImportJobTest.java
@@ -119,8 +119,8 @@ public class BoundaryImportJobTest {
         }
     }
 
-    private void addGetBoundariesIdsExpectation(String json) {
-        mockServer.getClient().when(request().withMethod("GET").withPath("/v1/boundaries/ids"))
+    private void addGetBoundariesInfosExpectation(String json) {
+        mockServer.getClient().when(request().withMethod("GET").withPath("/v1/boundaries/infos"))
             .respond(response().withStatusCode(200)
                 .withContentType(MediaType.JSON_UTF_8)
                 .withBody(json));
@@ -154,7 +154,7 @@ public class BoundaryImportJobTest {
         String[] args = null;
 
         // 1 zip container for boundaries on SFTP server, no boundary already present in cgmes boundary server, 2 boundaries will be imported
-        addGetBoundariesIdsExpectation("[]");
+        addGetBoundariesInfosExpectation("[]");
         addPostBoundaryExpectation(200);
 
         BoundaryAcquisitionJob.main(args);
@@ -163,7 +163,8 @@ public class BoundaryImportJobTest {
 
         // 1 boundary already present in cgmes boundary server, only 1 boundary will be imported
         mockServer.getClient().clear(request());
-        addGetBoundariesIdsExpectation("[\"urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb\"]");
+        addGetBoundariesInfosExpectation("[{\"id\":\"urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb\",\"filename\":\"20210315T0000Z__ENTSOE_TPBD_002.xml\",\"scenarioTime\":\"2020-02-02T00:00\"}]");
+
         addPostBoundaryExpectation(200);
 
         BoundaryAcquisitionJob.main(args);
@@ -172,7 +173,7 @@ public class BoundaryImportJobTest {
 
         // all boundaries already present in cgmes boundary server, no boundary will be imported
         mockServer.getClient().clear(request());
-        addGetBoundariesIdsExpectation("[\"urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb\", \"urn:uuid:11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa\"]");
+        addGetBoundariesInfosExpectation("[{\"id\":\"urn:uuid:22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb\",\"filename\":\"20210315T0000Z__ENTSOE_TPBD_002.xml\",\"scenarioTime\":\"2020-02-02T00:00\"},{\"id\":\"urn:uuid:11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa\",\"filename\":\"20210315T0000Z__ENTSOE_EQBD_002.xml\",\"scenarioTime\":\"2020-02-02T18:35\"}]");
         addPostBoundaryExpectation(200);
 
         BoundaryAcquisitionJob.main(args);


### PR DESCRIPTION
PR that must be merged before (migration merge orchestrator to Postgres) : 
https://github.com/gridsuite/merge-orchestrator-server/pull/50
https://github.com/gridsuite/deployment/pull/145

All following PR must be merged together : 
https://github.com/gridsuite/cgmes-boundary-server/pull/15
https://github.com/gridsuite/cgmes-boundary-import-job/pull/3
https://github.com/gridsuite/merge-orchestrator-server/pull/51
https://github.com/gridsuite/merge-notification-server/pull/16
https://github.com/gridsuite/gridmerge-app/pull/67